### PR TITLE
Fix documentation of I2C_WaitOnFlagUntilTimeout() to match code.

### DIFF
--- a/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_i2c.c
+++ b/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_i2c.c
@@ -6208,11 +6208,12 @@ static void I2C_DMAAbort(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief  This function handles I2C Communication Timeout.
+  * @brief This function handles I2C Communication Timeout.  It waits
+  *                until a flag is no longer in the specified status.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  Flag Specifies the I2C flag to check.
-  * @param  Status The new Flag status (SET or RESET).
+  * @param  Status The existing Flag status (SET or RESET).
   * @param  Timeout Timeout duration
   * @param  Tickstart Tick start value
   * @retval HAL status


### PR DESCRIPTION
I ran into this code while trying to account for some 25 millisecond delays in my code.

The `I2C_WaitOnFlagUntilTimeout()` is improperly commented.  It is documented as if it waits for a flag to change _to_ the specified status,  but reading the code shows it is actually waiting for the flag to change _from_ the specified status.

A quick grep shows the following duplicated functions are poorly documented in the same way:

```
Src/stm32f3xx_hal_usart.c:static HAL_StatusTypeDef [USART_WaitOnFlagUntilTimeout();
Src/stm32f3xx_hal_irda.c:static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout()
Src/stm32f3xx_hal_smbus.c:static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout();
Src/stm32f3xx_hal_smartcard.c:static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout();
```
I did not make the corresponding fix to these functions.