### PR TITLE
fix: missing handler callback for I2S DMA duplex circular mode

### DIFF
--- a/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_i2s_ex.c
+++ b/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_i2s_ex.c
@@ -946,6 +946,15 @@ static void I2SEx_TxRxDMACplt(DMA_HandleTypeDef *hdma)
       }
     }
   }
+  else if (hdma->Init.Mode == DMA_CIRCULAR)
+  {
+    /* Call user TxRx complete callback */
+#if (USE_HAL_I2S_REGISTER_CALLBACKS == 1U)
+    hi2s->TxRxCpltCallback(hi2s);
+#else
+    HAL_I2SEx_TxRxCpltCallback(hi2s);
+#endif /* USE_HAL_I2S_REGISTER_CALLBACKS */
+  }
 }
 
 /**


### PR DESCRIPTION
## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF3/blob/master/CONTRIBUTING.md) file.
